### PR TITLE
Fix carousel cell measurement

### DIFF
--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselTemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselTemplatedCell.cs
@@ -32,7 +32,10 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		public override CGSize Measure()
 		{
-			return new CGSize(_constraint.Width, _constraint.Height);
+			// Go through the measure pass even if the constraints are fixed
+			// to ensure arrange pass has the appropriate desired size in place.
+			PlatformHandler.VirtualView.Measure(_constraint.Width, _constraint.Height);
+			return _constraint;
 		}
 
 		protected override (bool, Size) NeedsContentSizeUpdate(Size currentSize)
@@ -42,7 +45,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)
 		{
-			return false;
+			return _constraint.IsCloseTo(attributes.Frame.Size);
 		}
 	}
 }

--- a/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/CarouselViewController.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 
 				if (cell is TemplatedCell templatedCell)
 				{
-					templatedCell.IsCarouselViewCell = true;
 					UpdateTemplatedCell(templatedCell, correctedIndexPath);
 				}
 			}
@@ -185,6 +184,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			var itemIndex = GetIndexFromIndexPath(indexPath);
 			return base.DetermineCellReuseId(NSIndexPath.FromItemSection(itemIndex, 0));
 		}
+
+		private protected override (Type CellType, string CellTypeReuseId) DetermineTemplatedCellType()
+			=> (typeof(CarouselTemplatedCell), "maui_carousel");
 
 		protected override void RegisterViewTypes()
 		{

--- a/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/ItemsViewController.cs
@@ -503,9 +503,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var dataTemplate = ItemsView.ItemTemplate.SelectDataTemplate(item, ItemsView);
 
 				var cellOrientation = ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Vertical ? "v" : "h";
-				var cellType = ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Vertical ? typeof(VerticalCell) : typeof(HorizontalCell);
+				(Type cellType, var cellTypeReuseId) = DetermineTemplatedCellType();
 
-				var reuseId = $"_maui_{cellOrientation}_{dataTemplate.Id}";
+				var reuseId = $"_{cellTypeReuseId}_{cellOrientation}_{dataTemplate.Id}";
 
 				if (!_cellReuseIds.Contains(reuseId))
 				{
@@ -519,6 +519,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			return ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal
 				? HorizontalDefaultCell.ReuseId
 				: VerticalDefaultCell.ReuseId;
+		}
+
+		private protected virtual (Type CellType, string CellTypeReuseId) DetermineTemplatedCellType()
+		{
+			return (ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Vertical ? typeof(VerticalCell) : typeof(HorizontalCell), "maui");
 		}
 
 		[Obsolete("Use DetermineCellReuseId(NSIndexPath indexPath) instead.")]

--- a/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
+++ b/src/Controls/src/Core/Handlers/Items/iOS/TemplatedCell.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 			remove => _weakEventManager.RemoveEventHandler(value);
 		}
 
-		internal bool IsCarouselViewCell;
-
 		protected CGSize ConstrainedSize;
 
 		protected nfloat ConstrainedDimension;
@@ -106,13 +104,6 @@ namespace Microsoft.Maui.Controls.Handlers.Items
 				var size = ConstrainedSize == default ? Measure() : ConstrainedSize;
 				_size = size.ToSize();
 				_needsArrange = true;
-
-				if (IsCarouselViewCell && PlatformHandler?.VirtualView is { } virtualView)
-				{
-					var constraints = new Size(preferredAttributes.Size.Width, double.PositiveInfinity);
-					_size = virtualView.Measure(constraints.Width, constraints.Height);
-				}
-				
 				_measureInvalidated = false;
 				preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, _size);
 				// Ensure we get a layout pass to arrange the virtual view.

--- a/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
+++ b/src/Controls/src/Core/Handlers/Items2/CarouselViewHandler2.iOS.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 		protected override UICollectionViewLayout SelectLayout()
 		{
-			bool IsHorizontal = VirtualView.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
-			UICollectionViewScrollDirection scrollDirection = IsHorizontal ? UICollectionViewScrollDirection.Horizontal : UICollectionViewScrollDirection.Vertical;
+			bool isHorizontal = VirtualView.ItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal;
+			UICollectionViewScrollDirection scrollDirection = isHorizontal ? UICollectionViewScrollDirection.Horizontal : UICollectionViewScrollDirection.Vertical;
 
 			NSCollectionLayoutDimension itemWidth = NSCollectionLayoutDimension.CreateFractionalWidth(1);
 			NSCollectionLayoutDimension itemHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
@@ -47,6 +47,11 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			NSCollectionLayoutDimension groupHeight = NSCollectionLayoutDimension.CreateFractionalHeight(1);
 			nfloat itemSpacing = 0;
 			NSCollectionLayoutGroup group = null;
+			
+			var layoutConfiguration = new UICollectionViewCompositionalLayoutConfiguration
+			{
+				ScrollDirection = scrollDirection
+			};
 
 			var layout = new UICollectionViewCompositionalLayout((sectionIndex, environment) =>
 			{
@@ -55,7 +60,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					return null;
 				}
 				double sectionMargin = 0.0;
-				if (!IsHorizontal)
+				if (!isHorizontal)
 				{
 					sectionMargin = VirtualView.PeekAreaInsets.VerticalThickness / 2;
 					var newGroupHeight = environment.Container.ContentSize.Height - VirtualView.PeekAreaInsets.VerticalThickness;
@@ -81,19 +86,19 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				if (OperatingSystem.IsIOSVersionAtLeast(16))
 				{
-					group = IsHorizontal ? NSCollectionLayoutGroup.GetHorizontalGroup(groupSize, item, 1) :
+					group = isHorizontal ? NSCollectionLayoutGroup.GetHorizontalGroup(groupSize, item, 1) :
 										   NSCollectionLayoutGroup.GetVerticalGroup(groupSize, item, 1);
 				}
 				else
 				{
-					group = IsHorizontal ? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, 1) :
+					group = isHorizontal ? NSCollectionLayoutGroup.CreateHorizontal(groupSize, item, 1) :
 										   NSCollectionLayoutGroup.CreateVertical(groupSize, item, 1);
 				}
 
 				// Create our section layout
 				var section = NSCollectionLayoutSection.Create(group: group);
 				section.InterGroupSpacing = itemSpacing;
-				section.OrthogonalScrollingBehavior = IsHorizontal ? UICollectionLayoutSectionOrthogonalScrollingBehavior.GroupPagingCentered : UICollectionLayoutSectionOrthogonalScrollingBehavior.None;
+				section.OrthogonalScrollingBehavior = isHorizontal ? UICollectionLayoutSectionOrthogonalScrollingBehavior.GroupPagingCentered : UICollectionLayoutSectionOrthogonalScrollingBehavior.None;
 				section.VisibleItemsInvalidationHandler = (items, offset, env) =>
 				{
 					//This will allow us to SetPosition when we are scrolling the items
@@ -152,7 +157,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				};
 				return section;
-			});
+			}, layoutConfiguration);
 
 			return layout;
 		}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselTemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselTemplatedCell2.cs
@@ -1,0 +1,22 @@
+#nullable disable
+using CoreGraphics;
+using Foundation;
+using Microsoft.Maui.Graphics;
+using UIKit;
+
+namespace Microsoft.Maui.Controls.Handlers.Items2
+{
+	internal sealed class CarouselTemplatedCell2 : TemplatedCell2
+	{
+		internal new const string ReuseId = "Microsoft.Maui.Controls.CarouselTemplatedCell2";
+
+		[Export("initWithFrame:")]
+		[Microsoft.Maui.Controls.Internals.Preserve(Conditional = true)]
+		public CarouselTemplatedCell2(CGRect frame) : base(frame)
+		{
+		}
+
+		private protected override Size GetMeasureConstraints(UICollectionViewLayoutAttributes preferredAttributes)
+			=> preferredAttributes.Size.ToSize();
+	}
+}

--- a/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/CarouselViewController2.cs
@@ -117,6 +117,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			return base.DetermineCellReuseId(itemIndex);
 		}
 
+		private protected override (Type CellType, string CellTypeReuseId) DetermineTemplatedCellType()
+			=> (typeof(CarouselTemplatedCell2), CarouselTemplatedCell2.ReuseId);
+
 		protected override Items.IItemsViewSource CreateItemsViewSource()
 		{
 			var itemsSource = ItemsSourceFactory2.CreateForCarouselView(ItemsView.ItemsSource, this, ItemsView.Loop);

--- a/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/ItemsViewController2.cs
@@ -330,10 +330,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 				var dataTemplate = ItemsView.ItemTemplate.SelectDataTemplate(item, ItemsView);
 
-				var cellType = typeof(TemplatedCell2);
-
 				var orientation = ScrollDirection == UICollectionViewScrollDirection.Horizontal ? "Horizontal" : "Vertical";
-				var reuseId = $"{TemplatedCell2.ReuseId}.{orientation}.{dataTemplate.Id}";
+				(Type cellType, var cellTypeReuseId) = DetermineTemplatedCellType();
+				var reuseId = $"{cellTypeReuseId}.{orientation}.{dataTemplate.Id}";
 
 				if (!_cellReuseIds.Contains(reuseId))
 				{
@@ -346,6 +345,9 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			return ScrollDirection == UICollectionViewScrollDirection.Horizontal ? HorizontalDefaultCell2.ReuseId : VerticalDefaultCell2.ReuseId;
 		}
+
+		private protected virtual (Type CellType, string CellTypeReuseId) DetermineTemplatedCellType()
+			=> (typeof(TemplatedCell2), TemplatedCell2.ReuseId);
 
 		protected virtual void RegisterViewTypes()
 		{

--- a/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
+++ b/src/Controls/src/Core/Handlers/Items2/iOS/TemplatedCell2.cs
@@ -86,9 +86,7 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 
 			if (PlatformHandler?.VirtualView is { } virtualView)
 			{
-				var constraints = ScrollDirection == UICollectionViewScrollDirection.Vertical
-					? new Size(preferredAttributes.Size.Width, double.PositiveInfinity)
-					: new Size(double.PositiveInfinity, preferredAttributes.Size.Height);
+				var constraints = GetMeasureConstraints(preferredAttributes);
 
 				if (_measureInvalidated || _cachedConstraints != constraints)
 				{
@@ -98,9 +96,12 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 					_needsArrange = true;
 				}
 
-				var size = ScrollDirection == UICollectionViewScrollDirection.Vertical
-					? new Size(preferredAttributes.Size.Width, _measuredSize.Height)
-					: new Size(_measuredSize.Width, preferredAttributes.Size.Height);
+				var preferredSize = preferredAttributes.Size;
+				// Use measured size only when unconstrained
+				var size = new Size(
+					double.IsPositiveInfinity(constraints.Width) ? _measuredSize.Width : preferredSize.Width,
+					double.IsPositiveInfinity(constraints.Height) ? _measuredSize.Height : preferredSize.Height
+				);
 
 				preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, size);
 				preferredAttributes.ZIndex = 2;
@@ -109,6 +110,14 @@ namespace Microsoft.Maui.Controls.Handlers.Items2
 			}
 
 			return preferredAttributes;
+		}
+
+		private protected virtual Size GetMeasureConstraints(UICollectionViewLayoutAttributes preferredAttributes)
+		{
+			var constraints = ScrollDirection == UICollectionViewScrollDirection.Vertical
+				? new Size(preferredAttributes.Size.Width, double.PositiveInfinity)
+				: new Size(double.PositiveInfinity, preferredAttributes.Size.Height);
+			return constraints;
 		}
 
 		public override void LayoutSubviews()


### PR DESCRIPTION
<!--
!!!!!!! MAIN IS THE ONLY ACTIVE BRANCH. MAKE SURE THIS PR IS TARGETING MAIN. !!!!!!! 
-->

### Description of Change

- Ensure Carousel2 layout has proper scroll direction (even if unused)
- Carousel1/2 should use a special templated cell type in order to execute a proper measurement pass where cells are constrained on both axis
